### PR TITLE
Update for gcc-12 and Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             DOCKER_TAG=unstable
             if [[ "$GIT_BRANCH" == "main" ]]; then DOCKER_TAG=stable ; fi
             docker build \
-              --progress=plain \
+              --target base-prod \
               -t ${DOCKER_USERNAME}/dtoo-base:${GIT_REV} \
               -t ${DOCKER_USERNAME}/dtoo-base:latest \
               -t ${DOCKER_USERNAME}/dtoo:${DOCKER_TAG} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
             DOCKER_TAG=unstable
             if [[ "$GIT_BRANCH" == "main" ]]; then DOCKER_TAG=stable ; fi
             docker build \
+              --progress=plain \
               --target base-prod \
               -t ${DOCKER_USERNAME}/dtoo-base:${GIT_REV} \
               -t ${DOCKER_USERNAME}/dtoo-base:latest \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,17 @@ jobs:
           name: Build and Push Docker image
           command: |
             GIT_REV=`git rev-parse HEAD`
-            docker build --progress=plain -t ${DOCKER_USERNAME}/dtoo-base:${GIT_REV} -t ${DOCKER_USERNAME}/dtoo-base:latest .
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            docker push --all-tags ${DOCKER_USERNAME}/dtoo-base
+            DOCKER_TAG=unstable
+            if [[ "$GIT_BRANCH" == "main" ]]; then DOCKER_TAG=stable ; fi
+            docker build \
+              --progress=plain \
+              -t ${DOCKER_USERNAME}/dtoo-base:${GIT_REV} \
+              -t ${DOCKER_USERNAME}/dtoo-base:latest \
+              -t ${DOCKER_USERNAME}/dtoo:${DOCKER_TAG} \
+              .
+            echo "$DOCKER_PASSWORD" \
+              | docker login -u "$DOCKER_USERNAME" --password-stdin
+            docker push \
+              --all-tags \
+              ${DOCKER_USERNAME}/dtoo-base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN zypper --non-interactive \
 RUN zypper --non-interactive \
   addrepo \
   https://download.opensuse.org/repositories/devel:tools:building/15.5/devel:tools:building.repo
+RUN zypper --non-interactive \
+  addrepo \
+  https://download.opensuse.org/repositories/devel:libraries:c_c++/15.5/devel:libraries:c_c++.repo
 RUN zypper --gpg-auto-import-keys refresh
 
 RUN zypper -n install \
@@ -38,25 +41,23 @@ RUN zypper -n install \
   occt-devel \
   openfoam2312 openfoam2312-common openfoam2312-default \
   openfoam2312-devel openfoam2312-doc openfoam2312-tools \
-  openfoam2312-tutorials
-
+  openfoam2312-tutorials \
+  nlohmann_json-devel
 
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
 ENV FC=/usr/bin/gfortran-12
 
-ARG NCPU=2
-
 RUN git clone https://github.com/ihs-ustutt/foamFine.git
 
 WORKDIR /dtOO-ThirdParty
 ENV DTOO_EXTERNLIBS=/dtOO-install
+ARG NCPU=2
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o cgns
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o openmesh
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o openvolumemesh
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o gmsh
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o moab
-RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o nlohmann_json
 
 WORKDIR /foamFine/of
 RUN . /usr/lib/openfoam/openfoam2312/etc/bashrc && wmake all
@@ -102,6 +103,7 @@ RUN zypper -n install \
   libQt5Svg-devel libqt5-qtxmlpatterns-devel libqt5-qttools-devel
 
 WORKDIR /dtOO-ThirdParty
+ARG NCPU
 RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o paraview
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM opensuse/leap:15.5
+FROM alpine/git AS repo
+WORKDIR /
+RUN git clone https://github.com/ihs-ustutt/dtOO-ThirdParty.git
+COPY . /dtOO-ThirdParty.local
 
-RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/science/15.5/science.repo
-RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/devel:tools:building/15.5/devel:tools:building.repo
+FROM opensuse/leap:15.5 AS base
+ARG CBASE=
+COPY --from=repo /dtOO-ThirdParty${CBASE} /dtOO-ThirdParty
+
+RUN zypper --non-interactive \
+  addrepo \
+  https://download.opensuse.org/repositories/science/15.5/science.repo
+RUN zypper --non-interactive \
+  addrepo \
+  https://download.opensuse.org/repositories/devel:tools:building/15.5/devel:tools:building.repo
 RUN zypper --gpg-auto-import-keys refresh
 
 RUN zypper -n install \
@@ -15,8 +26,8 @@ RUN zypper -n install \
   gzip \
   freetype2-devel tk-devel Mesa-libGL-devel fontconfig-devel \
   libXext-devel libXmu-devel libXi-devel \
-  python3 python3-devel python3-numpy python3-oslo.concurrency \
-  python3-scikit-learn python3-pip python3-paraview \
+  python311 python311-devel python311-numpy \
+  python311-pip  \
   python python-devel \
   vim \
   gcc12-fortran gcc12-c++ gcc12 \
@@ -29,14 +40,14 @@ RUN zypper -n install \
   openfoam2312-devel openfoam2312-doc openfoam2312-tools \
   openfoam2312-tutorials
 
+
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
 ENV FC=/usr/bin/gfortran-12
 
-ENV NCPU=2
+ARG NCPU=2
+ENV NCPU=${NCPU}
 
-WORKDIR /
-RUN git clone https://github.com/ihs-ustutt/dtOO-ThirdParty.git 
 RUN git clone https://github.com/ihs-ustutt/foamFine.git
 
 WORKDIR /dtOO-ThirdParty
@@ -56,6 +67,65 @@ RUN touch /root/.bashrc
 RUN echo "source /usr/lib/openfoam/openfoam2312/etc/bashrc" >> /root/.bashrc
 ENV FOAMFINE_DIR=/foamFine
 
-RUN pip3 install pyfoam
+RUN pip3.11 install pyfoam
+RUN pip3.11 install oslo.concurrency 
+RUN pip3.11 install scikit-learn
 
+ENV PATH=/dtOO-install/bin:$PATH
+
+FROM base AS base-prod
+COPY --from=base /bin             /bin
+COPY --from=base /boot            /boot
+COPY --from=base /dev             /dev
+COPY --from=base /dtOO-install    /dtOO-install
+COPY --from=base /etc             /etc
+COPY --from=base /foamFine        /foamFine
+COPY --from=base /home            /home
+COPY --from=base /lib             /lib
+COPY --from=base /lib64           /lib64
+COPY --from=base /mnt             /mnt
+COPY --from=base /opt             /opt
+COPY --from=base /proc            /proc
+COPY --from=base /root            /root
+COPY --from=base /run             /run
+COPY --from=base /sbin            /sbin
+COPY --from=base /selinux         /selinux
+COPY --from=base /srv             /srv
+COPY --from=base /sys             /sys
+COPY --from=base /tmp             /tmp
+COPY --from=base /usr             /usr
+COPY --from=base /var             /var
+
+FROM base AS ext
+COPY --from=base / /
+RUN zypper -n install \
+  libQt5OpenGL-devel libQt5Widgets-devel libQt5Network-devel \
+  libQt5Svg-devel libqt5-qtxmlpatterns-devel libqt5-qttools-devel
+
+WORKDIR /dtOO-ThirdParty
+RUN sh buildDep -i ${DTOO_EXTERNLIBS} -n ${NCPU} -o paraview
+WORKDIR /
+
+FROM ext AS ext-prod
+COPY --from=base /bin             /bin
+COPY --from=base /boot            /boot
+COPY --from=base /dev             /dev
+COPY --from=base /dtOO-install    /dtOO-install
+COPY --from=base /etc             /etc
+COPY --from=base /foamFine        /foamFine
+COPY --from=base /home            /home
+COPY --from=base /lib             /lib
+COPY --from=base /lib64           /lib64
+COPY --from=base /mnt             /mnt
+COPY --from=base /opt             /opt
+COPY --from=base /proc            /proc
+COPY --from=base /root            /root
+COPY --from=base /run             /run
+COPY --from=base /sbin            /sbin
+COPY --from=base /selinux         /selinux
+COPY --from=base /srv             /srv
+COPY --from=base /sys             /sys
+COPY --from=base /tmp             /tmp
+COPY --from=base /usr             /usr
+COPY --from=base /var             /var
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ ENV CXX=/usr/bin/g++-12
 ENV FC=/usr/bin/gfortran-12
 
 ARG NCPU=2
-ENV NCPU=${NCPU}
 
 RUN git clone https://github.com/ihs-ustutt/foamFine.git
 

--- a/ThirdParty.patch/gmsh.gmsh_4_13_1
+++ b/ThirdParty.patch/gmsh.gmsh_4_13_1
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46937b228..2efd85b7b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,7 +154,8 @@ if(ENABLE_PRIVATE_API)
+           "on the stable public API (gmsh/api) instead.")
+   file(GLOB_RECURSE HEADERS src/common/*.h src/numeric/*.h src/numeric/*.hpp
+        src/geo/*.h src/mesh/*.h src/solver/*.h src/post/*.h src/plugin/*.h
+-       src/graphics/*.h contrib/kbipack/*.h contrib/DiscreteIntegration/*.h
++       src/graphics/*.h contrib/kbipack/*.h src/parser/*.h
++       contrib/DiscreteIntegration/*.h
+        contrib/HighOrderMeshOptimizer/*.h contrib/MeshOptimizer/*.h
+        contrib/MeshQualityOptimizer/*.h)
+   set(GMSH_PRIVATE_API ${CMAKE_CURRENT_BINARY_DIR}/src/common/GmshConfig.h
+diff --git a/src/geo/GEntity.h b/src/geo/GEntity.h
+index 490760796..076f2fd2f 100644
+--- a/src/geo/GEntity.h
++++ b/src/geo/GEntity.h
+@@ -281,6 +281,7 @@ public:
+ 
+   // the model owning this entity
+   GModel *model() const { return _model; }
++  void setModel( GModel * model ) { _model = model; }
+ 
+   // get/set the tag of the entity
+   int tag() const { return _tag; }

--- a/buildDep
+++ b/buildDep
@@ -210,7 +210,7 @@ git_cmake_build \
 git_cmake_build \
   "occt" \
   "https://git.dev.opencascade.org/repos/occt.git" \
-  "V7_7_2" \
+  "V7_8_1" \
   "\
     -DINSTALL_DIR=${_installPrefix} \
     -DBUILD_RELEASE_DISABLE_EXCEPTIONS=FALSE \
@@ -222,7 +222,7 @@ git_cmake_build \
 git_cmake_build \
   "pythonocc-core" \
   "https://github.com/tpaviot/pythonocc-core.git" \
-  "7.7.2" \
+  "7.8.1" \
   "\
     -DOCCT_INCLUDE_DIR=${_installPrefix}/include/opencascade \
     -DOCCT_LIBRARY_DIR=${_installPrefix}/lib \
@@ -236,7 +236,7 @@ export CASROOT=${_installPrefix}
 git_cmake_build \
   "gmsh" \
   "https://gitlab.onelab.info/gmsh/gmsh.git" \
-  "gmsh_4_11_0" \
+  "gmsh_4_13_1" \
   "\
   -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
   -DENABLE_BUILD_SHARED=ON \
@@ -272,7 +272,7 @@ git_cmake_build \
 git_cmake_build \
   "moab" \
   "https://bitbucket.org/fathomteam/moab.git" \
-  "5.5.0" \
+  "5.5.1" \
   "\
   -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
   -DENABLE_CGM=OFF \
@@ -288,7 +288,7 @@ git_cmake_build \
 git_cmake_build \
   "cgal" \
   "https://github.com/CGAL/cgal" \
-  "v4.14.3" \
+  "v5.6.1" \
   "\
   -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
   -DCMAKE_BUILD_TYPE=Release \
@@ -324,10 +324,9 @@ git_cmake_build \
 git_cmake_build \
   "root" \
   "https://github.com/root-project/root" \
-  "v6-28-06" \
+  "v6-32-00" \
   "\
    -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
-   -Dminuit2=ON \
    -Dmathmore=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -Dbuiltin_openssl=FALSE \

--- a/buildDep
+++ b/buildDep
@@ -2,6 +2,7 @@
 
 _skipBuild=0
 _skipDownload=0
+_testRun=0
 
 usage() { 
   echo "$0 usage:" && grep " .)\ #" $0
@@ -13,6 +14,7 @@ git_cmake_build() {
   local _cloneCommand=$2
   local _checkoutCommand=$3
   local _cmakeConf=$4
+  local _addGitCommand="${5}"
 
   echo "# Process $_name ..."
   if [[ "$_dep" == "$_name" || "$_dep" == "all" ]]; then
@@ -22,29 +24,40 @@ git_cmake_build() {
     echo "#   ( G ) _skipDownload    : $_skipDownload"
     echo "#   ( L ) _checkoutCommand : $_checkoutCommand"
     echo "#   ( L ) _cmakeConf       : $_cmakeConf"
-  
-    cd $_pwd
-    if [[ "$_skipDownload" == "0" ]]; then
-      rm -rf ${_pwd}/${_name}
-      git clone $_cloneCommand $_name
-      if [ ! -z "$_checkoutCommand" ]; then
-        cd ${_pwd}/${_name}
-        git checkout $_checkoutCommand
-        if [ -f "${_patch}/${_name}.${_checkoutCommand}" ]; then
-          echo "#     > Apply Patch ${_name}.${_checkoutCommand}"
-          git apply ${_patch}/${_name}.${_checkoutCommand}
+    echo "#   ( L ) _addGitCommand   : $_addGitCommand"
+    
+    if [[ "$_testRun" == 0 ]]; then
+      cd $_pwd
+      if [[ "$_skipDownload" == "0" ]]; then
+        rm -rf ${_pwd}/${_name}
+        git clone $_cloneCommand $_name
+        if [ ! -z "$_checkoutCommand" ]; then
+          cd ${_pwd}/${_name}
+          git checkout $_checkoutCommand
+          if [ -f "${_patch}/${_name}.${_checkoutCommand}" ]; then
+            echo "#     > Apply Patch ${_name}.${_checkoutCommand}"
+            git apply ${_patch}/${_name}.${_checkoutCommand}
+          fi
+          if [ ! -z "$_addGitCommand" ]; then
+            echo "#     > Execute Git Command $_addGitCommand"
+            $_addGitCommand
+          fi
         fi
       fi
-    fi
-    mkdir -p ${_pwd}/build_$_name
-    if [[ "$_skipBuild" == "0" ]]; then
-      rm -rf ${_pwd}/build_$_name/*
+      mkdir -p ${_pwd}/build_$_name
+      if [[ "$_skipBuild" == "0" ]]; then
+        rm -rf ${_pwd}/build_$_name/*
+        cd ${_pwd}/build_$_name
+        cmake $_cmakeConf ../$_name
+        make -j${_nProcs}
+      fi
       cd ${_pwd}/build_$_name
-      cmake $_cmakeConf ../$_name
-      make -j${_nProcs}
-    fi
-    cd ${_pwd}/build_$_name
-    make -j${_nProcs} install
+      make -j${_nProcs} install
+    else
+      echo "  ->"
+      echo "  -> Test run"
+      echo "  ->"
+    fi   
   else
     echo "#   ...skip"
   fi
@@ -63,18 +76,24 @@ git_nobuild() {
     echo "#   ( G ) _skipDownload    : $_skipDownload"
     echo "#   ( L ) _checkoutCommand : $_checkoutCommand"
   
-    cd $_pwd
-    if [[ "$_skipDownload" == "0" ]]; then
-      rm -rf ${_pwd}/${_name}
-      git clone $_cloneCommand $_name
-      if [ ! -z "$_checkoutCommand" ]; then
-        cd ${_pwd}/${_name}
-        git checkout $_checkoutCommand
-        if [ -f "${_patch}/${_name}.${_checkoutCommand}" ]; then
-          echo "#     > Apply Patch ${_name}.${_checkoutCommand}"
-          git apply ${_patch}/${_name}.${_checkoutCommand}
+    if [[ "$_testRun" == 0 ]]; then
+      cd $_pwd
+      if [[ "$_skipDownload" == "0" ]]; then
+        rm -rf ${_pwd}/${_name}
+        git clone $_cloneCommand $_name
+        if [ ! -z "$_checkoutCommand" ]; then
+          cd ${_pwd}/${_name}
+          git checkout $_checkoutCommand
+          if [ -f "${_patch}/${_name}.${_checkoutCommand}" ]; then
+            echo "#     > Apply Patch ${_name}.${_checkoutCommand}"
+            git apply ${_patch}/${_name}.${_checkoutCommand}
+          fi
         fi
       fi
+    else
+      echo "  ->"
+      echo "  -> Test run"
+      echo "  ->"
     fi
   else
     echo "#   ...skip"
@@ -82,7 +101,7 @@ git_nobuild() {
 }
 
 [ $# -eq 0 ] && usage
-while getopts ":i:n:ho:bd" opt; do
+while getopts ":i:n:ho:bdt" opt; do
   case ${opt} in
     h) # Display help
       usage
@@ -105,6 +124,9 @@ while getopts ":i:n:ho:bd" opt; do
       ;;
     d) # Skip download
       _skipDownload=1
+      ;;
+    t) # Test run
+      _testRun=1
       ;;
     \?)
       echo "Invalid option: $OPTARG" 1>&2
@@ -165,19 +187,27 @@ git_cmake_build \
 #-------------------------------------------------------------------------------
 echo "# Build mpfr ..."
 if [[ "$_dep" == "mpfr" || "$_dep" == "all" ]]; then
-  cd $_pwd
-  if [[ "$_skipDownload" == "0" ]]; then
-    rm -rf ${_pwd}/mpfr-4.1.0
-    rm -rf ${_pwd}/mpfr-4.1.0.tar.xz
-    #curl -o mpfr-4.1.0.tar.xz https://www.mpfr.org/mpfr-current/mpfr-4.1.0.tar.xz
-    curl -o mpfr-4.1.0.tar.xz https://toolchains.bootlin.com/downloads/releases/sources/mpfr-4.1.0/mpfr-4.1.0.tar.xz
-    tar xvf mpfr-4.1.0.tar.xz
-  fi
-  if [[ "$_skipBuild" == "0" ]]; then
-    cd ${_pwd}/mpfr-4.1.0
-    ./configure \
-      --prefix=${_installPrefix}
+  if [[ "$_testRun" == 0 ]]; then
+    cd $_pwd
+    if [[ "$_skipDownload" == "0" ]]; then
+      rm -rf ${_pwd}/mpfr-4.1.0
+      rm -rf ${_pwd}/mpfr-4.1.0.tar.xz
+      #curl -o mpfr-4.1.0.tar.xz https://www.mpfr.org/mpfr-current/mpfr-4.1.0.tar.xz
+      curl \
+        -o mpfr-4.1.0.tar.xz \
+        https://toolchains.bootlin.com/downloads/releases/sources/mpfr-4.1.0/mpfr-4.1.0.tar.xz
+      tar xvf mpfr-4.1.0.tar.xz
+    fi
+    if [[ "$_skipBuild" == "0" ]]; then
+      cd ${_pwd}/mpfr-4.1.0
+      ./configure \
+        --prefix=${_installPrefix}
+    fi
     make -j${_nProcs} install
+  else
+    echo "  ->"
+    echo "  -> Test run"
+    echo "  ->"
   fi
 else
   echo "# ...skip"
@@ -335,3 +365,17 @@ git_cmake_build \
    -Dssl=FALSE \
    -Dx11=FALSE \
   "
+
+#-------------------------------------------------------------------------------
+# paraview
+#-------------------------------------------------------------------------------
+git_cmake_build \
+  "paraview" \
+  "https://github.com/Kitware/ParaView.git" \
+  "v5.12.1" \
+  "\
+  -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
+  -DPARAVIEW_USE_QTHELP=OFF \
+  -DPARAVIEW_USE_PYTHON=ON \
+  " \
+  "git submodule update --init --recursive"


### PR DESCRIPTION
Build process with docker changed. Within circleci the command
```
docker build -t dtoo-base --target base-prod .
```
is executed. It builds the image as before except that directory `/dtOO-ThirdParty` is not copied to the final container.

### Local build

Additionally, it is now possible to create a _local build_ by:
```
docker build --build-arg NCPU=32 --build-arg CBASE=.local -t dtoo-base --target base-prod .
```

The `NCPU` is optional and `CBASE` tells docker to copy the context directory (should be the repository directory) to `/dtOO-ThirdParty`. This enables local testing of the docker build.

### ext build

The target `ext-prod` builds also ParaView within the container. This is very time consuming and, therefore, not done within circleci.

- [x]  Use nlohmann_json from repository bfe169d