### PR TITLE
Disable embedded doc in ParaVIEW

### DIFF
--- a/buildDep
+++ b/buildDep
@@ -377,5 +377,6 @@ git_cmake_build \
   -DCMAKE_INSTALL_PREFIX=${_installPrefix} \
   -DPARAVIEW_USE_QTHELP=OFF \
   -DPARAVIEW_USE_PYTHON=ON \
+  -DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF \
   " \
   "git submodule update --init --recursive"


### PR DESCRIPTION
Disable embedded documentation to be able to compile paraview with Qt6
